### PR TITLE
Fix init message and simplify CI test execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,17 +45,12 @@ jobs:
     - name: Build
       run: cargo build --verbose
 
-    - name: Run unit tests
-      run: cargo test --lib
-
-    - name: Run init workflow tests
-      run: cargo test --test init_workflow_test
-
-    - name: Run session management tests (sequential)
-      run: cargo test --test session_management_test -- --test-threads=1
-
-    - name: Run workspace provisioning tests
-      run: cargo test --test workspace_provisioning_test
+    - name: Run all tests
+      run: |
+        cargo test --lib
+        cargo test --test init_workflow_test
+        cargo test --test workspace_provisioning_test
+        cargo test --test session_management_test -- --test-threads=1
 
   build:
     name: Build

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -72,7 +72,7 @@ pub fn execute(options: InitOptions) -> Result<()> {
 
     println!("🎯 Next steps:");
     println!("   1. Review agents/agents.yaml and customize agent configurations");
-    println!("   2. Run 'sprite install' to create agent worktrees");
+    println!("   2. Run 'sprite agents provision' to create agent worktrees");
     println!("   3. Run 'sprite start' to begin supervision session");
 
     Ok(())


### PR DESCRIPTION
- Change 'sprite install' to correct command 'sprite agents provision'
- Consolidate test steps into single run for efficiency
- Maintain sequential execution for session_management_test