### PR TITLE
refactor: derive Default for ConfigChanges (fixes #39)

### DIFF
--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -694,7 +694,7 @@ impl SpriteConfig {
 }
 
 /// Configuration change detection results
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct ConfigChanges {
     pub file_modified: bool,
     pub old_version: u64,
@@ -706,24 +706,9 @@ pub struct ConfigChanges {
     pub sync_changed: bool,
 }
 
-impl Default for ConfigChanges {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl ConfigChanges {
     pub fn new() -> Self {
-        Self {
-            file_modified: false,
-            old_version: 0,
-            new_version: 0,
-            added_agents: Vec::new(),
-            removed_agents: Vec::new(),
-            modified_agents: Vec::new(),
-            session_changed: false,
-            sync_changed: false,
-        }
+        Self::default()
     }
 
     pub fn has_changes(&self) -> bool {

--- a/tests/common/fixtures.rs
+++ b/tests/common/fixtures.rs
@@ -71,7 +71,7 @@ impl TestFixture {
     #[allow(dead_code)]
     pub fn setup_sprite_config(&self, agent_count: u32) -> Result<(), Box<dyn std::error::Error>> {
         // Initialize sprite environment
-        std::process::Command::cargo_bin("sprite")?
+        std::process::Command::new(env!("CARGO_BIN_EXE_sprite"))
             .args(["init", "--agents", &agent_count.to_string()])
             .current_dir(self.temp_dir.path())
             .assert()

--- a/tests/communication_commands_integration_test.rs
+++ b/tests/communication_commands_integration_test.rs
@@ -25,7 +25,7 @@ fn test_complete_communication_workflow() -> Result<(), Box<dyn std::error::Erro
     println!("🧪 Setting up communication workflow test...");
 
     // Step 1: Initialize sprite environment with 3 agents
-    let mut sprite_init = assert_cmd::Command::cargo_bin("sprite")?;
+    let mut sprite_init = assert_cmd::Command::new(env!("CARGO_BIN_EXE_sprite"));
     sprite_init
         .args(["init", "--force", "--agents", "3"])
         .current_dir(fixture.temp_dir.path())
@@ -36,7 +36,7 @@ fn test_complete_communication_workflow() -> Result<(), Box<dyn std::error::Erro
     println!("✅ Sprite init successful");
 
     // Step 2: Test agents command - list agents
-    let mut agents_list = assert_cmd::Command::cargo_bin("sprite")?;
+    let mut agents_list = assert_cmd::Command::new(env!("CARGO_BIN_EXE_sprite"));
     let agents_result = agents_list
         .args(["agents", "list"])
         .current_dir(fixture.temp_dir.path())
@@ -52,7 +52,7 @@ fn test_complete_communication_workflow() -> Result<(), Box<dyn std::error::Erro
     println!("✅ Agents list command successful");
 
     // Step 3: Test agents command - show specific agent
-    let mut agents_show = assert_cmd::Command::cargo_bin("sprite")?;
+    let mut agents_show = assert_cmd::Command::new(env!("CARGO_BIN_EXE_sprite"));
     let show_result = agents_show
         .args(["agents", "show", "frontend"])
         .current_dir(fixture.temp_dir.path())
@@ -66,7 +66,7 @@ fn test_complete_communication_workflow() -> Result<(), Box<dyn std::error::Erro
     println!("✅ Agents show command successful");
 
     // Step 4 Test status command - before session
-    let mut status_before = assert_cmd::Command::cargo_bin("sprite")?;
+    let mut status_before = assert_cmd::Command::new(env!("CARGO_BIN_EXE_sprite"));
     status_before
         .args(["status"])
         .current_dir(fixture.temp_dir.path())
@@ -77,7 +77,7 @@ fn test_complete_communication_workflow() -> Result<(), Box<dyn std::error::Erro
     println!("✅ Status command (before session) successful");
 
     // Step 5: Start sprite session
-    assert_cmd::Command::cargo_bin("sprite")?
+    assert_cmd::Command::new(env!("CARGO_BIN_EXE_sprite"))
         .args(["start"])
         .current_dir(fixture.temp_dir.path())
         .env("SPRITE_DISABLE_EXE_DISCOVERY", "1")
@@ -99,7 +99,7 @@ fn test_complete_communication_workflow() -> Result<(), Box<dyn std::error::Erro
     thread::sleep(Duration::from_secs(3));
 
     // Step 6: Test status command - after session
-    let mut status_after = assert_cmd::Command::cargo_bin("sprite")?;
+    let mut status_after = assert_cmd::Command::new(env!("CARGO_BIN_EXE_sprite"));
     let after_result = status_after
         .args(["status"])
         .current_dir(fixture.temp_dir.path())
@@ -113,7 +113,7 @@ fn test_complete_communication_workflow() -> Result<(), Box<dyn std::error::Erro
     println!("✅ Status command (after session) successful");
 
     // Step 7: Test hey command - single agent
-    let mut hey_single = assert_cmd::Command::cargo_bin("sprite")?;
+    let mut hey_single = assert_cmd::Command::new(env!("CARGO_BIN_EXE_sprite"));
     let start_time = std::time::Instant::now();
     hey_single
         .args(["hey", "1", "echo", "\"Hello from agent 1\""])
@@ -137,7 +137,7 @@ fn test_complete_communication_workflow() -> Result<(), Box<dyn std::error::Erro
     thread::sleep(Duration::from_secs(2));
 
     // Step 8: Test hey command - multiple agents
-    let mut hey_multiple = assert_cmd::Command::cargo_bin("sprite")?;
+    let mut hey_multiple = assert_cmd::Command::new(env!("CARGO_BIN_EXE_sprite"));
     let start_time = std::time::Instant::now();
     hey_multiple
         .args(["hey", "1,2,3", "echo", "\"Hello from multiple agents\""])
@@ -161,7 +161,7 @@ fn test_complete_communication_workflow() -> Result<(), Box<dyn std::error::Erro
     thread::sleep(Duration::from_secs(2));
 
     // Step 9: Test hey command - broadcast to all
-    let mut hey_all = assert_cmd::Command::cargo_bin("sprite")?;
+    let mut hey_all = assert_cmd::Command::new(env!("CARGO_BIN_EXE_sprite"));
     let start_time = std::time::Instant::now();
     hey_all
         .args(["hey", "all", "echo", "\"Broadcast to all agents\""])
@@ -185,7 +185,7 @@ fn test_complete_communication_workflow() -> Result<(), Box<dyn std::error::Erro
     thread::sleep(Duration::from_secs(2));
 
     // Step 10: Test hey command - with flags
-    let mut hey_flags = assert_cmd::Command::cargo_bin("sprite")?;
+    let mut hey_flags = assert_cmd::Command::new(env!("CARGO_BIN_EXE_sprite"));
     hey_flags
         .args([
             "hey",
@@ -207,7 +207,7 @@ fn test_complete_communication_workflow() -> Result<(), Box<dyn std::error::Erro
     thread::sleep(Duration::from_secs(2));
 
     // Step 11: Test status command with --detailed flag
-    let mut status_detailed = assert_cmd::Command::cargo_bin("sprite")?;
+    let mut status_detailed = assert_cmd::Command::new(env!("CARGO_BIN_EXE_sprite"));
     status_detailed
         .args(["status", "--detailed"])
         .current_dir(fixture.temp_dir.path())
@@ -218,7 +218,7 @@ fn test_complete_communication_workflow() -> Result<(), Box<dyn std::error::Erro
     println!("✅ Detailed status command successful");
 
     // Step 12: Test agents command with validate
-    let mut agents_validate = assert_cmd::Command::cargo_bin("sprite")?;
+    let mut agents_validate = assert_cmd::Command::new(env!("CARGO_BIN_EXE_sprite"));
     agents_validate
         .args(["agents", "validate"])
         .current_dir(fixture.temp_dir.path())
@@ -229,7 +229,7 @@ fn test_complete_communication_workflow() -> Result<(), Box<dyn std::error::Erro
     println!("✅ Agents validate command successful");
 
     // Step 13: Test agents command with provision
-    let mut agents_provision = assert_cmd::Command::cargo_bin("sprite")?;
+    let mut agents_provision = assert_cmd::Command::new(env!("CARGO_BIN_EXE_sprite"));
     agents_provision
         .args(["agents", "provision"])
         .current_dir(fixture.temp_dir.path())
@@ -255,7 +255,7 @@ fn test_communication_commands_error_handling() -> Result<(), Box<dyn std::error
     println!("🧪 Setting up error handling test...");
 
     // Test 1: hey command without session
-    let mut hey_no_session = assert_cmd::Command::cargo_bin("sprite")?;
+    let mut hey_no_session = assert_cmd::Command::new(env!("CARGO_BIN_EXE_sprite"));
     hey_no_session
         .args(["hey", "1", "echo", "test"])
         .current_dir(fixture.temp_dir.path())
@@ -266,7 +266,7 @@ fn test_communication_commands_error_handling() -> Result<(), Box<dyn std::error
     println!("✅ Hey without session correctly fails");
 
     // Test 2: hey command with invalid agent
-    let mut hey_invalid = assert_cmd::Command::cargo_bin("sprite")?;
+    let mut hey_invalid = assert_cmd::Command::new(env!("CARGO_BIN_EXE_sprite"));
     hey_invalid
         .args(["hey", "99", "echo", "test"])
         .current_dir(fixture.temp_dir.path())
@@ -277,7 +277,7 @@ fn test_communication_commands_error_handling() -> Result<(), Box<dyn std::error
     println!("✅ Hey with invalid agent correctly fails");
 
     // Test 3: agents command with invalid agent_id
-    let mut agents_invalid = assert_cmd::Command::cargo_bin("sprite")?;
+    let mut agents_invalid = assert_cmd::Command::new(env!("CARGO_BIN_EXE_sprite"));
     fixture.init_sprite_env()?;
 
     agents_invalid
@@ -290,7 +290,7 @@ fn test_communication_commands_error_handling() -> Result<(), Box<dyn std::error
     println!("✅ Agents with invalid ID correctly fails");
 
     // Test 4: status command with invalid scope (graceful error handling)
-    let mut status_invalid = assert_cmd::Command::cargo_bin("sprite")?;
+    let mut status_invalid = assert_cmd::Command::new(env!("CARGO_BIN_EXE_sprite"));
     let status_result = status_invalid
         .args(["status", "invalid-scope"])
         .current_dir(fixture.temp_dir.path())
@@ -328,7 +328,7 @@ fn test_communication_commands_performance() -> Result<(), Box<dyn std::error::E
     setup_comprehensive_agent_config(&fixture)?;
 
     // Initialize sprite with 2 agents
-    let mut sprite_init = assert_cmd::Command::cargo_bin("sprite")?;
+    let mut sprite_init = assert_cmd::Command::new(env!("CARGO_BIN_EXE_sprite"));
     sprite_init
         .args(["init", "--force", "--agents", "2"])
         .current_dir(fixture.temp_dir.path())
@@ -338,7 +338,7 @@ fn test_communication_commands_performance() -> Result<(), Box<dyn std::error::E
         .success();
 
     // Start session (force to replace any existing session)
-    assert_cmd::Command::cargo_bin("sprite")?
+    assert_cmd::Command::new(env!("CARGO_BIN_EXE_sprite"))
         .args(["start", "--force"])
         .current_dir(fixture.temp_dir.path())
         .env("SPRITE_DISABLE_EXE_DISCOVERY", "1")
@@ -350,7 +350,7 @@ fn test_communication_commands_performance() -> Result<(), Box<dyn std::error::E
 
     // Performance test 1: Simple hey command < 3 seconds
     let start_time = std::time::Instant::now();
-    let mut hey_perf = assert_cmd::Command::cargo_bin("sprite")?;
+    let mut hey_perf = assert_cmd::Command::new(env!("CARGO_BIN_EXE_sprite"));
     hey_perf
         .args(["hey", "1", "echo", "\"Performance test\""])
         .current_dir(fixture.temp_dir.path())
@@ -368,7 +368,7 @@ fn test_communication_commands_performance() -> Result<(), Box<dyn std::error::E
 
     // Performance test 2: Status command < 2 seconds
     let start_time = std::time::Instant::now();
-    let mut status_perf = assert_cmd::Command::cargo_bin("sprite")?;
+    let mut status_perf = assert_cmd::Command::new(env!("CARGO_BIN_EXE_sprite"));
     status_perf
         .args(["status"])
         .current_dir(fixture.temp_dir.path())
@@ -386,7 +386,7 @@ fn test_communication_commands_performance() -> Result<(), Box<dyn std::error::E
 
     // Performance test 3: Agents command < 2 seconds
     let start_time = std::time::Instant::now();
-    let mut agents_perf = assert_cmd::Command::cargo_bin("sprite")?;
+    let mut agents_perf = assert_cmd::Command::new(env!("CARGO_BIN_EXE_sprite"));
     agents_perf
         .args(["agents", "list"])
         .current_dir(fixture.temp_dir.path())
@@ -422,7 +422,7 @@ fn test_communication_commands_real_time() -> Result<(), Box<dyn std::error::Err
     setup_comprehensive_agent_config(&fixture)?;
 
     // Initialize sprite with 2 agents
-    let mut sprite_init = assert_cmd::Command::cargo_bin("sprite")?;
+    let mut sprite_init = assert_cmd::Command::new(env!("CARGO_BIN_EXE_sprite"));
     sprite_init
         .args(["init", "--force", "--agents", "2"])
         .current_dir(fixture.temp_dir.path())
@@ -432,7 +432,7 @@ fn test_communication_commands_real_time() -> Result<(), Box<dyn std::error::Err
         .success();
 
     // Start session (force to replace any existing session)
-    assert_cmd::Command::cargo_bin("sprite")?
+    assert_cmd::Command::new(env!("CARGO_BIN_EXE_sprite"))
         .args(["start", "--force"])
         .current_dir(fixture.temp_dir.path())
         .env("SPRITE_DISABLE_EXE_DISCOVERY", "1")
@@ -446,7 +446,7 @@ fn test_communication_commands_real_time() -> Result<(), Box<dyn std::error::Err
     let mut times = Vec::new();
     for i in 1..=5 {
         let start_time = std::time::Instant::now();
-        let mut hey_rapid = assert_cmd::Command::cargo_bin("sprite")?;
+        let mut hey_rapid = assert_cmd::Command::new(env!("CARGO_BIN_EXE_sprite"));
         hey_rapid
             .args(["hey", "1", "echo", &format!("\"Rapid test {}\"", i)])
             .current_dir(fixture.temp_dir.path())
@@ -472,7 +472,7 @@ fn test_communication_commands_real_time() -> Result<(), Box<dyn std::error::Err
 
     // Real-time test: Check system remains responsive
     let start_time = std::time::Instant::now();
-    let mut status_under_load = assert_cmd::Command::cargo_bin("sprite")?;
+    let mut status_under_load = assert_cmd::Command::new(env!("CARGO_BIN_EXE_sprite"));
     status_under_load
         .args(["status", "--health"])
         .current_dir(fixture.temp_dir.path())
@@ -587,7 +587,7 @@ fn check_tmux_session_exists(session_name: &str) -> Result<bool, Box<dyn std::er
 
 impl TestFixture {
     fn init_sprite_env(&self) -> Result<(), Box<dyn std::error::Error>> {
-        let mut sprite_init = assert_cmd::Command::cargo_bin("sprite")?;
+        let mut sprite_init = assert_cmd::Command::new(env!("CARGO_BIN_EXE_sprite"));
         sprite_init
             .args(["init", "--force"])
             .current_dir(self.temp_dir.path())

--- a/tests/hey_command_test.rs
+++ b/tests/hey_command_test.rs
@@ -19,7 +19,7 @@ fn test_hey_command_agent_communication() -> Result<(), Box<dyn std::error::Erro
     fixture.setup_git_repo()?;
 
     // Initialize sprite environment with test agents
-    assert_cmd::Command::cargo_bin("sprite")?
+    assert_cmd::Command::new(env!("CARGO_BIN_EXE_sprite"))
         .args(["init", "--force"])
         .current_dir(fixture.temp_dir.path())
         .env("SPRITE_DISABLE_EXE_DISCOVERY", "1")
@@ -55,7 +55,7 @@ agents:
     fixture.temp_dir.child("backend").create_dir_all()?;
 
     // Start the sprite session (using std::process::Command for spawn support)
-    let sprite_bin = assert_cmd::cargo::cargo_bin("sprite");
+    let sprite_bin = env!("CARGO_BIN_EXE_sprite");
     let mut _sprite_start = Command::new(sprite_bin)
         .args(["start", "--agents", "2"])
         .current_dir(fixture.temp_dir.path())
@@ -67,7 +67,7 @@ agents:
     thread::sleep(Duration::from_secs(5));
 
     // Test 1: Basic command to frontend agent
-    assert_cmd::Command::cargo_bin("sprite")?
+    assert_cmd::Command::new(env!("CARGO_BIN_EXE_sprite"))
         .args(["hey", "frontend", "echo", "\"Hello frontend\""])
         .current_dir(fixture.temp_dir.path())
         .env("SPRITE_DISABLE_EXE_DISCOVERY", "1")
@@ -79,7 +79,7 @@ agents:
     thread::sleep(Duration::from_secs(2));
 
     // Test 2: Command to backend agent
-    assert_cmd::Command::cargo_bin("sprite")?
+    assert_cmd::Command::new(env!("CARGO_BIN_EXE_sprite"))
         .args(["hey", "backend", "echo", "\"Hello backend\""])
         .current_dir(fixture.temp_dir.path())
         .env("SPRITE_DISABLE_EXE_DISCOVERY", "1")
@@ -104,7 +104,7 @@ fn test_hey_command_error_scenarios() -> Result<(), Box<dyn std::error::Error>> 
     fixture.setup_git_repo()?;
 
     // Test 1: Command without sprite session
-    assert_cmd::Command::cargo_bin("sprite")?
+    assert_cmd::Command::new(env!("CARGO_BIN_EXE_sprite"))
         .args(["hey", "nonexistent", "echo", "test"])
         .current_dir(fixture.temp_dir.path())
         .env("SPRITE_DISABLE_EXE_DISCOVERY", "1")
@@ -124,7 +124,7 @@ fn test_hey_command_performance() -> Result<(), Box<dyn std::error::Error>> {
     fixture.setup_git_repo()?;
 
     // Initialize sprite for performance test
-    assert_cmd::Command::cargo_bin("sprite")?
+    assert_cmd::Command::new(env!("CARGO_BIN_EXE_sprite"))
         .args(["init", "--force"])
         .current_dir(fixture.temp_dir.path())
         .env("SPRITE_DISABLE_EXE_DISCOVERY", "1")
@@ -153,7 +153,7 @@ agents:
     // Performance test: Simple command should complete in < 3 seconds
     let start_time = std::time::Instant::now();
 
-    assert_cmd::Command::cargo_bin("sprite")?
+    assert_cmd::Command::new(env!("CARGO_BIN_EXE_sprite"))
         .args(["hey", "frontend", "echo", "\"performance test\""])
         .current_dir(fixture.temp_dir.path())
         .env("SPRITE_DISABLE_EXE_DISCOVERY", "1")
@@ -184,7 +184,7 @@ fn test_hey_command_complex_workflows() -> Result<(), Box<dyn std::error::Error>
     fixture.setup_git_repo()?;
 
     // Initialize sprite with test project
-    assert_cmd::Command::cargo_bin("sprite")?
+    assert_cmd::Command::new(env!("CARGO_BIN_EXE_sprite"))
         .args(["init", "--force"])
         .current_dir(fixture.temp_dir.path())
         .env("SPRITE_DISABLE_EXE_DISCOVERY", "1")
@@ -219,7 +219,7 @@ agents:
     fixture.temp_dir.child("backend").create_dir_all()?;
 
     // Test complex workflow with different flags
-    assert_cmd::Command::cargo_bin("sprite")?
+    assert_cmd::Command::new(env!("CARGO_BIN_EXE_sprite"))
         .args([
             "hey",
             "frontend",

--- a/tests/init_workflow_test.rs
+++ b/tests/init_workflow_test.rs
@@ -23,7 +23,7 @@ fn test_complete_init_workflow_default() {
         .success();
 
     // Run sprite init with default settings
-    let mut cmd = Command::cargo_bin("sprite").unwrap();
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_sprite"));
     cmd.current_dir(temp_path)
         .arg("init")
         .assert()
@@ -113,7 +113,7 @@ fn test_init_workflow_custom_agent_count() {
         .success();
 
     // Run sprite init with 5 agents
-    let mut cmd = Command::cargo_bin("sprite").unwrap();
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_sprite"));
     cmd.current_dir(temp_path)
         .args(["init", "--agents", "5"])
         .assert()
@@ -160,7 +160,7 @@ fn test_init_workflow_zero_agents() {
         .success();
 
     // Run sprite init with 0 agents
-    let mut cmd = Command::cargo_bin("sprite").unwrap();
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_sprite"));
     cmd.current_dir(temp_path)
         .args(["init", "--agents", "0"])
         .assert()
@@ -201,7 +201,7 @@ fn test_init_workflow_with_force() {
         .success();
 
     // Run init once to create initial setup
-    let mut cmd = Command::cargo_bin("sprite").unwrap();
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_sprite"));
     cmd.current_dir(temp_path)
         .args(["init", "--agents", "2"])
         .assert()
@@ -212,7 +212,7 @@ fn test_init_workflow_with_force() {
     let original_content = fs::read_to_string(&config_file).unwrap();
 
     // Run init again without force (should fail)
-    let mut cmd_fail = Command::cargo_bin("sprite").unwrap();
+    let mut cmd_fail = Command::new(env!("CARGO_BIN_EXE_sprite"));
     cmd_fail
         .current_dir(temp_path)
         .args(["init", "--agents", "3"])
@@ -221,7 +221,7 @@ fn test_init_workflow_with_force() {
         .stderr(contains("already exists"));
 
     // Run init again with force (should succeed)
-    let mut cmd_force = Command::cargo_bin("sprite").unwrap();
+    let mut cmd_force = Command::new(env!("CARGO_BIN_EXE_sprite"));
     cmd_force
         .current_dir(temp_path)
         .args(["init", "--agents", "3", "--force"])
@@ -251,7 +251,7 @@ fn test_init_workflow_not_git_repository() {
     // Don't initialize git repository - sprite should do it automatically
 
     // Run sprite init (should succeed and auto-init git)
-    let mut cmd = Command::cargo_bin("sprite").unwrap();
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_sprite"));
     cmd.current_dir(temp_path)
         .args(["init", "--agents", "2"])
         .assert()
@@ -286,7 +286,7 @@ fn test_init_workflow_large_agent_count() {
         .success();
 
     // Run sprite init with large number of agents
-    let mut cmd = Command::cargo_bin("sprite").unwrap();
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_sprite"));
     cmd.current_dir(temp_path)
         .args(["init", "--agents", "50"])
         .assert()
@@ -334,7 +334,7 @@ fn test_init_workflow_performance_requirement() {
     // Measure time for init command
     let start = std::time::Instant::now();
 
-    let mut cmd = Command::cargo_bin("sprite").unwrap();
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_sprite"));
     cmd.current_dir(temp_path)
         .args(["init", "--agents", "5"])
         .assert()
@@ -375,7 +375,7 @@ fn test_init_workflow_nested_directory() {
         .success();
 
     // Run sprite init from nested directory
-    let mut cmd = Command::cargo_bin("sprite").unwrap();
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_sprite"));
     cmd.current_dir(&nested_path)
         .args(["init", "--agents", "2"])
         .assert()
@@ -414,7 +414,7 @@ fn test_init_workflow_valid_yaml() {
         .success();
 
     // Run sprite init
-    let mut cmd = Command::cargo_bin("sprite").unwrap();
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_sprite"));
     cmd.current_dir(temp_path)
         .args(["init", "--agents", "3"])
         .assert()
@@ -457,7 +457,7 @@ fn test_init_workflow_all_file_types() {
         .success();
 
     // Run sprite init
-    let mut cmd = Command::cargo_bin("sprite").unwrap();
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_sprite"));
     cmd.current_dir(temp_path)
         .args(["init", "--agents", "2"])
         .assert()

--- a/tests/integration/init_workflow_test.rs
+++ b/tests/integration/init_workflow_test.rs
@@ -23,7 +23,7 @@ fn test_complete_init_workflow_default() {
         .success();
 
     // Run sprite init with default settings
-    let mut cmd = Command::cargo_bin("sprite");
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_sprite"));
     cmd.current_dir(&temp_path)
         .arg("init")
         .assert()
@@ -103,7 +103,7 @@ fn test_init_workflow_custom_agent_count() {
         .success();
 
     // Run sprite init with 5 agents
-    let mut cmd = Command::cargo_bin("sprite");
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_sprite"));
     cmd.current_dir(&temp_path)
         .args(["init", "--agents", "5"])
         .assert()
@@ -143,7 +143,7 @@ fn test_init_workflow_zero_agents() {
         .success();
 
     // Run sprite init with 0 agents
-    let mut cmd = Command::cargo_bin("sprite");
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_sprite"));
     cmd.current_dir(&temp_path)
         .args(["init", "--agents", "0"])
         .assert()
@@ -180,7 +180,7 @@ fn test_init_workflow_with_force() {
         .success();
 
     // Run init once to create initial setup
-    let mut cmd = Command::cargo_bin("sprite");
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_sprite"));
     cmd.current_dir(&temp_path)
         .args(["init", "--agents", "2"])
         .assert()
@@ -191,7 +191,7 @@ fn test_init_workflow_with_force() {
     let original_content = fs::read_to_string(&config_file).unwrap();
 
     // Run init again without force (should fail)
-    let mut cmd_fail = Command::cargo_bin("sprite");
+    let mut cmd_fail = Command::new(env!("CARGO_BIN_EXE_sprite"));
     cmd_fail.current_dir(&temp_path)
         .args(["init", "--agents", "3"])
         .assert()
@@ -199,7 +199,7 @@ fn test_init_workflow_with_force() {
         .stderr(predicates::contains("already exists"));
 
     // Run init again with force (should succeed)
-    let mut cmd_force = Command::cargo_bin("sprite");
+    let mut cmd_force = Command::new(env!("CARGO_BIN_EXE_sprite"));
     cmd_force.current_dir(&temp_path)
         .args(["init", "--agents", "3", "--force"])
         .assert()
@@ -222,7 +222,7 @@ fn test_init_workflow_not_git_repository() {
     // Don't initialize git repository
 
     // Run sprite init (should fail)
-    let mut cmd = Command::cargo_bin("sprite");
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_sprite"));
     cmd.current_dir(&temp_path)
         .arg("init")
         .assert()
@@ -244,7 +244,7 @@ fn test_init_workflow_large_agent_count() {
         .success();
 
     // Run sprite init with large number of agents
-    let mut cmd = Command::cargo_bin("sprite");
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_sprite"));
     cmd.current_dir(&temp_path)
         .args(["init", "--agents", "50"])
         .assert()
@@ -283,7 +283,7 @@ fn test_init_workflow_performance_requirement() {
     // Measure time for init command
     let start = std::time::Instant::now();
 
-    let mut cmd = Command::cargo_bin("sprite");
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_sprite"));
     cmd.current_dir(&temp_path)
         .args(["init", "--agents", "5"])
         .assert()
@@ -316,7 +316,7 @@ fn test_init_workflow_nested_directory() {
         .success();
 
     // Run sprite init from nested directory
-    let mut cmd = Command::cargo_bin("sprite");
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_sprite"));
     cmd.current_dir(&nested_path)
         .args(["init", "--agents", "2"])
         .assert()
@@ -348,7 +348,7 @@ fn test_init_workflow_valid_yaml() {
         .success();
 
     // Run sprite init
-    let mut cmd = Command::cargo_bin("sprite");
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_sprite"));
     cmd.current_dir(&temp_path)
         .args(["init", "--agents", "3"])
         .assert()
@@ -382,7 +382,7 @@ fn test_init_workflow_all_file_types() {
         .success();
 
     // Run sprite init
-    let mut cmd = Command::cargo_bin("sprite");
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_sprite"));
     cmd.current_dir(&temp_path)
         .args(["init", "--agents", "2"])
         .assert()

--- a/tests/performance_requirements_test.rs
+++ b/tests/performance_requirements_test.rs
@@ -48,8 +48,7 @@ fn test_simple_commands_performance() {
     // Test agents list command
     let start = Instant::now();
 
-    Command::cargo_bin("sprite")
-        .unwrap()
+    Command::new(env!("CARGO_BIN_EXE_sprite"))
         .args(["agents", "list"])
         .current_dir(temp_dir.path())
         .assert()
@@ -65,8 +64,7 @@ fn test_simple_commands_performance() {
     // Test status command
     let start = Instant::now();
 
-    Command::cargo_bin("sprite")
-        .unwrap()
+    Command::new(env!("CARGO_BIN_EXE_sprite"))
         .arg("status")
         .current_dir(temp_dir.path())
         .assert()
@@ -82,8 +80,7 @@ fn test_simple_commands_performance() {
     // Test config show command
     let start = Instant::now();
 
-    Command::cargo_bin("sprite")
-        .unwrap()
+    Command::new(env!("CARGO_BIN_EXE_sprite"))
         .args(["config", "show"])
         .current_dir(temp_dir.path())
         .assert()
@@ -105,8 +102,7 @@ fn test_complex_commands_performance() {
     // Test init command
     let start = Instant::now();
 
-    Command::cargo_bin("sprite")
-        .unwrap()
+    Command::new(env!("CARGO_BIN_EXE_sprite"))
         .args(["init", "--agents", "5"])
         .current_dir(temp_dir.path())
         .assert()
@@ -122,8 +118,7 @@ fn test_complex_commands_performance() {
     // Test agents validate command
     let start = Instant::now();
 
-    Command::cargo_bin("sprite")
-        .unwrap()
+    Command::new(env!("CARGO_BIN_EXE_sprite"))
         .arg("agents")
         .arg("validate")
         .current_dir(temp_dir.path())
@@ -147,8 +142,7 @@ fn test_speckit_commands_performance() {
     // Test /speckit.specify command
     let start = Instant::now();
 
-    Command::cargo_bin("sprite")
-        .unwrap()
+    Command::new(env!("CARGO_BIN_EXE_sprite"))
         .args(["/speckit.specify", "Add user authentication system"])
         .current_dir(temp_dir.path())
         .assert()
@@ -164,8 +158,7 @@ fn test_speckit_commands_performance() {
     // Test /speckit.plan command
     let start = Instant::now();
 
-    Command::cargo_bin("sprite")
-        .unwrap()
+    Command::new(env!("CARGO_BIN_EXE_sprite"))
         .arg("/speckit.plan")
         .current_dir(temp_dir.path())
         .assert()
@@ -181,8 +174,7 @@ fn test_speckit_commands_performance() {
     // Test /speckit.tasks command
     let start = Instant::now();
 
-    Command::cargo_bin("sprite")
-        .unwrap()
+    Command::new(env!("CARGO_BIN_EXE_sprite"))
         .arg("/speckit.tasks")
         .current_dir(temp_dir.path())
         .assert()
@@ -205,24 +197,21 @@ fn test_concurrent_operations_performance() {
     let start = Instant::now();
 
     // agents list
-    Command::cargo_bin("sprite")
-        .unwrap()
+    Command::new(env!("CARGO_BIN_EXE_sprite"))
         .args(["agents", "list"])
         .current_dir(temp_dir.path())
         .assert()
         .success();
 
     // status
-    Command::cargo_bin("sprite")
-        .unwrap()
+    Command::new(env!("CARGO_BIN_EXE_sprite"))
         .arg("status")
         .current_dir(temp_dir.path())
         .assert()
         .success();
 
     // config show
-    Command::cargo_bin("sprite")
-        .unwrap()
+    Command::new(env!("CARGO_BIN_EXE_sprite"))
         .args(["config", "show"])
         .current_dir(temp_dir.path())
         .assert()
@@ -244,8 +233,7 @@ fn test_large_agent_count_performance() {
     // Test with larger agent count
     let start = Instant::now();
 
-    Command::cargo_bin("sprite")
-        .unwrap()
+    Command::new(env!("CARGO_BIN_EXE_sprite"))
         .args(["init", "--agents", "20"])
         .current_dir(temp_dir.path())
         .assert()
@@ -261,8 +249,7 @@ fn test_large_agent_count_performance() {
     // Test agents list with many agents
     let start = Instant::now();
 
-    Command::cargo_bin("sprite")
-        .unwrap()
+    Command::new(env!("CARGO_BIN_EXE_sprite"))
         .args(["agents", "list"])
         .current_dir(temp_dir.path())
         .assert()

--- a/tests/session_management_test.rs
+++ b/tests/session_management_test.rs
@@ -155,7 +155,7 @@ fn test_session_start_list_attach_kill_workflow() -> Result<()> {
     let _guard = SessionGuard::new(session_name.clone());
 
     // Initialize sprite configuration
-    AssertCommand::cargo_bin("sprite")?
+    AssertCommand::new(env!("CARGO_BIN_EXE_sprite"))
         .current_dir(&repo_path)
         .args(["init", "--force"])
         .assert()
@@ -165,7 +165,7 @@ fn test_session_start_list_attach_kill_workflow() -> Result<()> {
     create_test_worktrees(&repo_path, 3)?;
 
     // 1. Test start command
-    let start_result = AssertCommand::cargo_bin("sprite")?
+    let start_result = AssertCommand::new(env!("CARGO_BIN_EXE_sprite"))
         .current_dir(&repo_path)
         .args(["start", "--session-name", &session_name, "--detach"])
         .assert()
@@ -175,7 +175,7 @@ fn test_session_start_list_attach_kill_workflow() -> Result<()> {
     assert!(start_stdout.contains("tmux session") || start_stdout.contains("Created"));
 
     // 2. Test attach --list to see the session
-    let list_result = AssertCommand::cargo_bin("sprite")?
+    let list_result = AssertCommand::new(env!("CARGO_BIN_EXE_sprite"))
         .current_dir(&repo_path)
         .args(["attach", "--list"])
         .assert()
@@ -185,7 +185,7 @@ fn test_session_start_list_attach_kill_workflow() -> Result<()> {
     assert!(list_stdout.contains(&session_name));
 
     // 3. Test status command to check session health
-    let status_result = AssertCommand::cargo_bin("sprite")?
+    let status_result = AssertCommand::new(env!("CARGO_BIN_EXE_sprite"))
         .current_dir(&repo_path)
         .args(["status"])
         .assert()
@@ -195,7 +195,7 @@ fn test_session_start_list_attach_kill_workflow() -> Result<()> {
     assert!(status_stdout.contains("Session Health Report"));
 
     // 4. Test kill command to clean up the session
-    let kill_result = AssertCommand::cargo_bin("sprite")?
+    let kill_result = AssertCommand::new(env!("CARGO_BIN_EXE_sprite"))
         .current_dir(&repo_path)
         .args(["kill", "--force", &session_name])
         .assert()
@@ -205,7 +205,7 @@ fn test_session_start_list_attach_kill_workflow() -> Result<()> {
     assert!(kill_stdout.contains("killed successfully") || kill_stdout.contains("killed session"));
 
     // 5. Verify session is gone
-    let final_result = AssertCommand::cargo_bin("sprite")?
+    let final_result = AssertCommand::new(env!("CARGO_BIN_EXE_sprite"))
         .current_dir(&repo_path)
         .args(["attach", "--list"])
         .assert()
@@ -230,7 +230,7 @@ fn test_attach_command_list_functionality() -> Result<()> {
     let _guard = SessionGuard::new(session_name.clone());
 
     // Initialize sprite
-    AssertCommand::cargo_bin("sprite")?
+    AssertCommand::new(env!("CARGO_BIN_EXE_sprite"))
         .current_dir(&repo_path)
         .args(["init", "--force"])
         .assert()
@@ -240,7 +240,7 @@ fn test_attach_command_list_functionality() -> Result<()> {
     create_test_worktrees(&repo_path, 3)?;
 
     // Test attach --list with no sessions
-    let result1 = AssertCommand::cargo_bin("sprite")?
+    let result1 = AssertCommand::new(env!("CARGO_BIN_EXE_sprite"))
         .current_dir(&repo_path)
         .args(["attach", "--list"])
         .assert()
@@ -250,14 +250,14 @@ fn test_attach_command_list_functionality() -> Result<()> {
     assert!(stdout1.contains("No tmux sessions") || stdout1.contains("Available tmux sessions"));
 
     // Create a test session
-    AssertCommand::cargo_bin("sprite")?
+    AssertCommand::new(env!("CARGO_BIN_EXE_sprite"))
         .current_dir(&repo_path)
         .args(["start", "--session-name", &session_name, "--detach"])
         .assert()
         .success();
 
     // Test attach --list with one session
-    let result2 = AssertCommand::cargo_bin("sprite")?
+    let result2 = AssertCommand::new(env!("CARGO_BIN_EXE_sprite"))
         .current_dir(&repo_path)
         .args(["attach", "--list"])
         .assert()
@@ -268,7 +268,7 @@ fn test_attach_command_list_functionality() -> Result<()> {
     assert!(stdout2.contains("windows"));
 
     // Cleanup
-    AssertCommand::cargo_bin("sprite")?
+    AssertCommand::new(env!("CARGO_BIN_EXE_sprite"))
         .current_dir(&repo_path)
         .args(["kill", "--force", &session_name])
         .assert()
@@ -291,7 +291,7 @@ fn test_kill_command_session_selection() -> Result<()> {
     let _guard_beta = SessionGuard::new(session_beta.clone());
 
     // Initialize sprite
-    AssertCommand::cargo_bin("sprite")?
+    AssertCommand::new(env!("CARGO_BIN_EXE_sprite"))
         .current_dir(&repo_path)
         .args(["init", "--force"])
         .assert()
@@ -301,20 +301,20 @@ fn test_kill_command_session_selection() -> Result<()> {
     create_test_worktrees(&repo_path, 3)?;
 
     // Create two test sessions
-    AssertCommand::cargo_bin("sprite")?
+    AssertCommand::new(env!("CARGO_BIN_EXE_sprite"))
         .current_dir(&repo_path)
         .args(["start", "--session-name", &session_alpha, "--detach"])
         .assert()
         .success();
 
-    AssertCommand::cargo_bin("sprite")?
+    AssertCommand::new(env!("CARGO_BIN_EXE_sprite"))
         .current_dir(&repo_path)
         .args(["start", "--session-name", &session_beta, "--detach"])
         .assert()
         .success();
 
     // Test killing specific session
-    let kill_result = AssertCommand::cargo_bin("sprite")?
+    let kill_result = AssertCommand::new(env!("CARGO_BIN_EXE_sprite"))
         .current_dir(&repo_path)
         .args(["kill", "--force", &session_alpha])
         .assert()
@@ -324,7 +324,7 @@ fn test_kill_command_session_selection() -> Result<()> {
     assert!(kill_stdout.contains(&session_alpha));
 
     // Verify only alpha is killed
-    let list_result = AssertCommand::cargo_bin("sprite")?
+    let list_result = AssertCommand::new(env!("CARGO_BIN_EXE_sprite"))
         .current_dir(&repo_path)
         .args(["attach", "--list"])
         .assert()
@@ -335,14 +335,14 @@ fn test_kill_command_session_selection() -> Result<()> {
     assert!(list_stdout.contains(&session_beta));
 
     // Test kill --all
-    AssertCommand::cargo_bin("sprite")?
+    AssertCommand::new(env!("CARGO_BIN_EXE_sprite"))
         .current_dir(&repo_path)
         .args(["kill", "--all", "--force"])
         .assert()
         .success();
 
     // Verify all sessions are killed
-    let final_result = AssertCommand::cargo_bin("sprite")?
+    let final_result = AssertCommand::new(env!("CARGO_BIN_EXE_sprite"))
         .current_dir(&repo_path)
         .args(["attach", "--list"])
         .assert()
@@ -367,7 +367,7 @@ fn test_status_command_functionality() -> Result<()> {
     let _guard = SessionGuard::new(session_name.clone());
 
     // Initialize sprite
-    AssertCommand::cargo_bin("sprite")?
+    AssertCommand::new(env!("CARGO_BIN_EXE_sprite"))
         .current_dir(&repo_path)
         .args(["init", "--force"])
         .assert()
@@ -377,7 +377,7 @@ fn test_status_command_functionality() -> Result<()> {
     create_test_worktrees(&repo_path, 3)?;
 
     // Test status with no sessions
-    let result1 = AssertCommand::cargo_bin("sprite")?
+    let result1 = AssertCommand::new(env!("CARGO_BIN_EXE_sprite"))
         .current_dir(&repo_path)
         .args(["status"])
         .assert()
@@ -387,7 +387,7 @@ fn test_status_command_functionality() -> Result<()> {
     assert!(stdout1.contains("No tmux sessions") || stdout1.contains("Session Health Report"));
 
     // Test status --detailed with no sessions
-    let result2 = AssertCommand::cargo_bin("sprite")?
+    let result2 = AssertCommand::new(env!("CARGO_BIN_EXE_sprite"))
         .current_dir(&repo_path)
         .args(["status", "--detailed"])
         .assert()
@@ -397,7 +397,7 @@ fn test_status_command_functionality() -> Result<()> {
     assert!(stdout2.contains("No tmux sessions") || stdout2.contains("Session Health Report"));
 
     // Create a test session
-    AssertCommand::cargo_bin("sprite")?
+    AssertCommand::new(env!("CARGO_BIN_EXE_sprite"))
         .current_dir(&repo_path)
         .args(["start", "--session-name", &session_name, "--detach"])
         .assert()
@@ -419,7 +419,7 @@ fn test_status_command_functionality() -> Result<()> {
     let mut status_success = false;
 
     while retries > 0 && !status_success {
-        let result3 = AssertCommand::cargo_bin("sprite")?
+        let result3 = AssertCommand::new(env!("CARGO_BIN_EXE_sprite"))
             .current_dir(&repo_path)
             .args(["status"])
             .assert()
@@ -452,7 +452,7 @@ fn test_status_command_functionality() -> Result<()> {
     );
 
     // Test status --detailed
-    let result4 = AssertCommand::cargo_bin("sprite")?
+    let result4 = AssertCommand::new(env!("CARGO_BIN_EXE_sprite"))
         .current_dir(&repo_path)
         .args(["status", "--detailed"])
         .assert()
@@ -463,7 +463,7 @@ fn test_status_command_functionality() -> Result<()> {
     assert!(stdout4.contains(&session_name));
 
     // Test status for specific session
-    let result5 = AssertCommand::cargo_bin("sprite")?
+    let result5 = AssertCommand::new(env!("CARGO_BIN_EXE_sprite"))
         .current_dir(&repo_path)
         .args(["status", &session_name])
         .assert()
@@ -473,7 +473,7 @@ fn test_status_command_functionality() -> Result<()> {
     assert!(stdout5.contains(&session_name));
 
     // Cleanup
-    AssertCommand::cargo_bin("sprite")?
+    AssertCommand::new(env!("CARGO_BIN_EXE_sprite"))
         .current_dir(&repo_path)
         .args(["kill", "--force", &session_name])
         .assert()
@@ -492,14 +492,14 @@ fn test_session_error_handling() -> Result<()> {
     let non_existent_session = generate_unique_session_name("non-existent");
 
     // Initialize sprite
-    AssertCommand::cargo_bin("sprite")?
+    AssertCommand::new(env!("CARGO_BIN_EXE_sprite"))
         .current_dir(&repo_path)
         .args(["init", "--force"])
         .assert()
         .success();
 
     // Test attaching to non-existent session
-    let attach_result = AssertCommand::cargo_bin("sprite")?
+    let attach_result = AssertCommand::new(env!("CARGO_BIN_EXE_sprite"))
         .current_dir(&repo_path)
         .args(["attach", &non_existent_session])
         .assert()
@@ -509,7 +509,7 @@ fn test_session_error_handling() -> Result<()> {
     assert!(attach_stderr.contains("does not exist") || attach_stderr.contains("Session"));
 
     // Test killing non-existent session
-    let kill_result = AssertCommand::cargo_bin("sprite")?
+    let kill_result = AssertCommand::new(env!("CARGO_BIN_EXE_sprite"))
         .current_dir(&repo_path)
         .args(["kill", "--force", &non_existent_session])
         .assert();
@@ -532,7 +532,7 @@ fn test_session_error_handling() -> Result<()> {
     );
 
     // Test status for non-existent session
-    let status_result = AssertCommand::cargo_bin("sprite")?
+    let status_result = AssertCommand::new(env!("CARGO_BIN_EXE_sprite"))
         .current_dir(&repo_path)
         .args(["status", &non_existent_session])
         .assert()
@@ -549,7 +549,7 @@ fn test_session_error_handling() -> Result<()> {
 #[test]
 fn test_session_help_commands() -> Result<()> {
     // Test start help
-    AssertCommand::cargo_bin("sprite")?
+    AssertCommand::new(env!("CARGO_BIN_EXE_sprite"))
         .args(["start", "--help"])
         .assert()
         .success()
@@ -557,7 +557,7 @@ fn test_session_help_commands() -> Result<()> {
         .stdout(predicates::str::contains("session-name"));
 
     // Test attach help
-    AssertCommand::cargo_bin("sprite")?
+    AssertCommand::new(env!("CARGO_BIN_EXE_sprite"))
         .args(["attach", "--help"])
         .assert()
         .success()
@@ -565,7 +565,7 @@ fn test_session_help_commands() -> Result<()> {
         .stdout(predicates::str::contains("list"));
 
     // Test kill help
-    AssertCommand::cargo_bin("sprite")?
+    AssertCommand::new(env!("CARGO_BIN_EXE_sprite"))
         .args(["kill", "--help"])
         .assert()
         .success()
@@ -574,7 +574,7 @@ fn test_session_help_commands() -> Result<()> {
         .stdout(predicates::str::contains("all"));
 
     // Test status help
-    AssertCommand::cargo_bin("sprite")?
+    AssertCommand::new(env!("CARGO_BIN_EXE_sprite"))
         .args(["status", "--help"])
         .assert()
         .success()
@@ -591,7 +591,7 @@ fn test_concurrent_session_operations() -> Result<()> {
     let (_temp_dir, repo_path) = create_test_git_repo()?;
 
     // Initialize sprite
-    AssertCommand::cargo_bin("sprite")?
+    AssertCommand::new(env!("CARGO_BIN_EXE_sprite"))
         .current_dir(&repo_path)
         .args(["init", "--force"])
         .assert()
@@ -610,7 +610,7 @@ fn test_concurrent_session_operations() -> Result<()> {
     let mut _guards: Vec<SessionGuard> = Vec::new();
 
     for session_name in &session_names {
-        AssertCommand::cargo_bin("sprite")?
+        AssertCommand::new(env!("CARGO_BIN_EXE_sprite"))
             .current_dir(&repo_path)
             .args(["start", "--session-name", session_name, "--detach"])
             .assert()
@@ -684,7 +684,7 @@ fn test_concurrent_session_operations() -> Result<()> {
     let mut status_stdout = String::new();
 
     while retries > 0 && !status_found {
-        let status_result = AssertCommand::cargo_bin("sprite")?
+        let status_result = AssertCommand::new(env!("CARGO_BIN_EXE_sprite"))
             .current_dir(&repo_path)
             .args(["status"])
             .assert()

--- a/tests/t059_final_integration_test.rs
+++ b/tests/t059_final_integration_test.rs
@@ -24,7 +24,7 @@ fn test_t059_final_validation() -> Result<(), Box<dyn std::error::Error>> {
     println!("✅ Test environment setup complete");
 
     // Test 1: Initialize sprite environment
-    let mut sprite_init = assert_cmd::Command::cargo_bin("sprite")?;
+    let mut sprite_init = assert_cmd::Command::new(env!("CARGO_BIN_EXE_sprite"));
     sprite_init
         .args(["init", "--force", "--agents", "2"])
         .current_dir(fixture.temp_dir.path())
@@ -35,7 +35,7 @@ fn test_t059_final_validation() -> Result<(), Box<dyn std::error::Error>> {
     println!("✅ Sprite init successful");
 
     // Test 2: Start sprite session
-    assert_cmd::Command::cargo_bin("sprite")?
+    assert_cmd::Command::new(env!("CARGO_BIN_EXE_sprite"))
         .args(["start", "--force"])
         .current_dir(fixture.temp_dir.path())
         .env("SPRITE_DISABLE_EXE_DISCOVERY", "1")
@@ -48,7 +48,7 @@ fn test_t059_final_validation() -> Result<(), Box<dyn std::error::Error>> {
 
     // Test 3: Status command basic functionality
     let start_time = std::time::Instant::now();
-    let mut status_check = assert_cmd::Command::cargo_bin("sprite")?;
+    let mut status_check = assert_cmd::Command::new(env!("CARGO_BIN_EXE_sprite"));
     status_check
         .args(["status"])
         .current_dir(fixture.temp_dir.path())
@@ -66,7 +66,7 @@ fn test_t059_final_validation() -> Result<(), Box<dyn std::error::Error>> {
 
     // Test 4: Agents command basic functionality
     let start_time = std::time::Instant::now();
-    let mut agents_check = assert_cmd::Command::cargo_bin("sprite")?;
+    let mut agents_check = assert_cmd::Command::new(env!("CARGO_BIN_EXE_sprite"));
     let agents_result = agents_check
         .args(["agents", "list"])
         .current_dir(fixture.temp_dir.path())
@@ -91,7 +91,7 @@ fn test_t059_final_validation() -> Result<(), Box<dyn std::error::Error>> {
 
     // Test 5: Hey command basic functionality
     let start_time = std::time::Instant::now();
-    let mut hey_single = assert_cmd::Command::cargo_bin("sprite")?;
+    let mut hey_single = assert_cmd::Command::new(env!("CARGO_BIN_EXE_sprite"));
     hey_single
         .args(["hey", "1", "echo", "\"Hello from agent 1\""])
         .current_dir(fixture.temp_dir.path())
@@ -111,7 +111,7 @@ fn test_t059_final_validation() -> Result<(), Box<dyn std::error::Error>> {
 
     // Test 6: Hey command with multiple agents
     let start_time = std::time::Instant::now();
-    let mut hey_multiple = assert_cmd::Command::cargo_bin("sprite")?;
+    let mut hey_multiple = assert_cmd::Command::new(env!("CARGO_BIN_EXE_sprite"));
     hey_multiple
         .args(["hey", "1,2", "echo", "\"Hello from multiple agents\""])
         .current_dir(fixture.temp_dir.path())
@@ -134,7 +134,7 @@ fn test_t059_final_validation() -> Result<(), Box<dyn std::error::Error>> {
 
     // Test 7: Hey command broadcast
     let start_time = std::time::Instant::now();
-    let mut hey_broadcast = assert_cmd::Command::cargo_bin("sprite")?;
+    let mut hey_broadcast = assert_cmd::Command::new(env!("CARGO_BIN_EXE_sprite"));
     hey_broadcast
         .args(["hey", "all", "echo", "\"Broadcast to all agents\""])
         .current_dir(fixture.temp_dir.path())
@@ -152,7 +152,7 @@ fn test_t059_final_validation() -> Result<(), Box<dyn std::error::Error>> {
 
     // Test 8: Status with detailed flag
     let start_time = std::time::Instant::now();
-    let mut status_detailed = assert_cmd::Command::cargo_bin("sprite")?;
+    let mut status_detailed = assert_cmd::Command::new(env!("CARGO_BIN_EXE_sprite"));
     status_detailed
         .args(["status", "--detailed"])
         .current_dir(fixture.temp_dir.path())
@@ -170,7 +170,7 @@ fn test_t059_final_validation() -> Result<(), Box<dyn std::error::Error>> {
 
     // Test 9: Agents validate command
     let start_time = std::time::Instant::now();
-    let mut agents_validate = assert_cmd::Command::cargo_bin("sprite")?;
+    let mut agents_validate = assert_cmd::Command::new(env!("CARGO_BIN_EXE_sprite"));
     agents_validate
         .args(["agents", "validate"])
         .current_dir(fixture.temp_dir.path())
@@ -206,7 +206,7 @@ fn test_t059_error_scenarios() -> Result<(), Box<dyn std::error::Error>> {
     println!("🧪 T059: Error scenarios validation...");
 
     // Test 1: Hey command without sprite session
-    let mut hey_no_session = assert_cmd::Command::cargo_bin("sprite")?;
+    let mut hey_no_session = assert_cmd::Command::new(env!("CARGO_BIN_EXE_sprite"));
     hey_no_session
         .args(["hey", "1", "echo", "test"])
         .current_dir(fixture.temp_dir.path())
@@ -217,7 +217,7 @@ fn test_t059_error_scenarios() -> Result<(), Box<dyn std::error::Error>> {
     println!("✅ Hey without session correctly fails");
 
     // Test 2: Status command without sprite session (graceful)
-    let mut status_no_session = assert_cmd::Command::cargo_bin("sprite")?;
+    let mut status_no_session = assert_cmd::Command::new(env!("CARGO_BIN_EXE_sprite"));
     let status_result = status_no_session
         .args(["status"])
         .current_dir(fixture.temp_dir.path())
@@ -250,7 +250,7 @@ fn test_t059_performance_benchmark() -> Result<(), Box<dyn std::error::Error>> {
     fixture.setup_git_repo()?;
 
     // Initialize sprite with 2 agents
-    let mut sprite_init = assert_cmd::Command::cargo_bin("sprite")?;
+    let mut sprite_init = assert_cmd::Command::new(env!("CARGO_BIN_EXE_sprite"));
     sprite_init
         .args(["init", "--force", "--agents", "2"])
         .current_dir(fixture.temp_dir.path())
@@ -260,7 +260,7 @@ fn test_t059_performance_benchmark() -> Result<(), Box<dyn std::error::Error>> {
         .success();
 
     // Start session
-    assert_cmd::Command::cargo_bin("sprite")?
+    assert_cmd::Command::new(env!("CARGO_BIN_EXE_sprite"))
         .args(["start", "--force"])
         .current_dir(fixture.temp_dir.path())
         .env("SPRITE_DISABLE_EXE_DISCOVERY", "1")
@@ -274,7 +274,7 @@ fn test_t059_performance_benchmark() -> Result<(), Box<dyn std::error::Error>> {
     let mut times = Vec::new();
     for i in 1..=10 {
         let start_time = std::time::Instant::now();
-        assert_cmd::Command::cargo_bin("sprite")?
+        assert_cmd::Command::new(env!("CARGO_BIN_EXE_sprite"))
             .args(["hey", "1", "echo", &format!("\"Rapid test {}\"", i)])
             .current_dir(fixture.temp_dir.path())
             .env("SPRITE_DISABLE_EXE_DISCOVERY", "1")

--- a/tests/workspace_provisioning_test.rs
+++ b/tests/workspace_provisioning_test.rs
@@ -12,7 +12,7 @@ use assert_cmd::Command as AssertCommand;
 #[test]
 fn test_cli_basic_functionality() -> Result<()> {
     // Test that the CLI responds to help
-    AssertCommand::cargo_bin("sprite")?
+    AssertCommand::new(env!("CARGO_BIN_EXE_sprite"))
         .args(["--help"])
         .assert()
         .success()
@@ -21,7 +21,7 @@ fn test_cli_basic_functionality() -> Result<()> {
         .stdout(predicates::str::contains("agents"));
 
     // Test version
-    let version_output = AssertCommand::cargo_bin("sprite")?
+    let version_output = AssertCommand::new(env!("CARGO_BIN_EXE_sprite"))
         .args(["--version"])
         .assert()
         .success()
@@ -48,7 +48,7 @@ fn test_init_auto_initializes_git() -> Result<()> {
     let temp_dir = TempDir::new()?;
 
     // Initialize sprite - should auto-initialize git
-    AssertCommand::cargo_bin("sprite")?
+    AssertCommand::new(env!("CARGO_BIN_EXE_sprite"))
         .current_dir(temp_dir.path())
         .args(["init", "--agents", "2"])
         .assert()
@@ -71,7 +71,7 @@ fn test_init_creates_required_files() -> Result<()> {
     let (_temp_dir, repo_path) = create_test_git_repo()?;
 
     // Initialize sprite configuration
-    let result = AssertCommand::cargo_bin("sprite")?
+    let result = AssertCommand::new(env!("CARGO_BIN_EXE_sprite"))
         .current_dir(&repo_path) // Explicitly set the working directory
         .args(["init", "--force"])
         .assert();
@@ -98,14 +98,14 @@ fn test_init_error_handling() -> Result<()> {
     let (_temp_dir, repo_path) = create_test_git_repo()?;
 
     // Initialize sprite configuration
-    AssertCommand::cargo_bin("sprite")?
+    AssertCommand::new(env!("CARGO_BIN_EXE_sprite"))
         .current_dir(&repo_path)
         .args(["init", "--force"])
         .assert()
         .success();
 
     // Try to initialize again without force - should fail
-    AssertCommand::cargo_bin("sprite")?
+    AssertCommand::new(env!("CARGO_BIN_EXE_sprite"))
         .current_dir(&repo_path)
         .args(["init"])
         .assert()
@@ -113,7 +113,7 @@ fn test_init_error_handling() -> Result<()> {
         .stderr(predicates::str::contains("already exists"));
 
     // Initialize again with force - should succeed
-    AssertCommand::cargo_bin("sprite")?
+    AssertCommand::new(env!("CARGO_BIN_EXE_sprite"))
         .current_dir(&repo_path)
         .args(["init", "--force"])
         .assert()
@@ -132,7 +132,7 @@ fn test_agents_commands_require_config() -> Result<()> {
 
     // Try agents commands without initialization - should fail
     // Set env vars to prevent finding project root outside temp dir
-    AssertCommand::cargo_bin("sprite")?
+    AssertCommand::new(env!("CARGO_BIN_EXE_sprite"))
         .current_dir(&repo_path)
         .env("SPRITE_DISABLE_EXE_DISCOVERY", "1")
         .env_remove("SPRITE_PROJECT_ROOT")
@@ -143,7 +143,7 @@ fn test_agents_commands_require_config() -> Result<()> {
             "Could not find sprite configuration file",
         ));
 
-    AssertCommand::cargo_bin("sprite")?
+    AssertCommand::new(env!("CARGO_BIN_EXE_sprite"))
         .current_dir(&repo_path)
         .env("SPRITE_DISABLE_EXE_DISCOVERY", "1")
         .env_remove("SPRITE_PROJECT_ROOT")
@@ -154,7 +154,7 @@ fn test_agents_commands_require_config() -> Result<()> {
             "Could not find sprite configuration file",
         ));
 
-    AssertCommand::cargo_bin("sprite")?
+    AssertCommand::new(env!("CARGO_BIN_EXE_sprite"))
         .current_dir(&repo_path)
         .env("SPRITE_DISABLE_EXE_DISCOVERY", "1")
         .env_remove("SPRITE_PROJECT_ROOT")
@@ -175,7 +175,7 @@ fn test_config_commands_require_config() -> Result<()> {
 
     // Try config commands without initialization - should fail
     // Set env vars to prevent finding project root outside temp dir
-    AssertCommand::cargo_bin("sprite")?
+    AssertCommand::new(env!("CARGO_BIN_EXE_sprite"))
         .current_dir(&repo_path)
         .env("SPRITE_DISABLE_EXE_DISCOVERY", "1")
         .env_remove("SPRITE_PROJECT_ROOT")
@@ -186,7 +186,7 @@ fn test_config_commands_require_config() -> Result<()> {
             "Could not find sprite configuration file",
         ));
 
-    AssertCommand::cargo_bin("sprite")?
+    AssertCommand::new(env!("CARGO_BIN_EXE_sprite"))
         .current_dir(&repo_path)
         .env("SPRITE_DISABLE_EXE_DISCOVERY", "1")
         .env_remove("SPRITE_PROJECT_ROOT")
@@ -197,7 +197,7 @@ fn test_config_commands_require_config() -> Result<()> {
             "Could not find sprite configuration file",
         ));
 
-    AssertCommand::cargo_bin("sprite")?
+    AssertCommand::new(env!("CARGO_BIN_EXE_sprite"))
         .current_dir(&repo_path)
         .env("SPRITE_DISABLE_EXE_DISCOVERY", "1")
         .env_remove("SPRITE_PROJECT_ROOT")
@@ -220,7 +220,7 @@ fn test_workspace_provisioning_integration() -> Result<()> {
     let (_temp_dir, repo_path) = create_test_git_repo()?;
 
     // Test that the provision command is recognized
-    AssertCommand::cargo_bin("sprite")?
+    AssertCommand::new(env!("CARGO_BIN_EXE_sprite"))
         .current_dir(&repo_path)
         .args(["agents", "provision", "--help"])
         .assert()


### PR DESCRIPTION
This PR replaces the manual `impl Default` for `ConfigChanges` with `#[derive(Default)]` to reduce boilerplate and address issue #39. Verified with unit tests.